### PR TITLE
WIP: Add an Example module

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -7,7 +7,8 @@
         "src"
     ],
     "exposed-modules": [
-        "EventSource"
+        "EventSource",
+        "EventSource.LowLevel"
     ],
     "dependencies": {
         "elm-lang/core": "4.0.1 <= v < 5.0.0"

--- a/elm-package.json
+++ b/elm-package.json
@@ -12,5 +12,6 @@
     "dependencies": {
         "elm-lang/core": "4.0.1 <= v < 5.0.0"
     },
+    "native-modules": true,
     "elm-version": "0.17.0 <= v < 0.18.0"
 }

--- a/example/elm-package.json
+++ b/example/elm-package.json
@@ -1,7 +1,7 @@
 {
     "version": "1.0.0",
     "summary": "Example for the OpenSensorsIO/eventsource package",
-    "repository": "https://github.com/OpenSensorsIO/eventsource.git",
+    "repository": "https://github.com/opensensorsio/eventsource.git",
     "license": "MIT",
     "source-directories": [
         "src",
@@ -14,5 +14,5 @@
         "elm-lang/core": "4.0.5 <= v < 5.0.0",
         "elm-lang/html": "1.1.0 <= v < 2.0.0"
     },
-    "elm-version": "0.17.0 <= v < 0.18.0"
+    "elm-version": "0.17.1 <= v < 0.18.0"
 }

--- a/example/elm-package.json
+++ b/example/elm-package.json
@@ -4,11 +4,10 @@
     "repository": "https://github.com/OpenSensorsIO/eventsource.git",
     "license": "BSD3",
     "source-directories": [
-        "src/",
-        "../src/"
+        "src",
+        "../src"
     ],
     "exposed-modules": [],
-    "native-modules": true,
     "dependencies": {
         "NoRedInk/elm-decode-pipeline": "2.0.0 <= v < 3.0.0",
         "elm-lang/core": "4.0.5 <= v < 5.0.0",

--- a/example/elm-package.json
+++ b/example/elm-package.json
@@ -1,6 +1,6 @@
 {
     "version": "1.0.0",
-    "summary": "helpful summary of your project, less than 80 characters",
+    "summary": "Example for the OpenSensorsIO/eventsource package",
     "repository": "https://github.com/OpenSensorsIO/eventsource.git",
     "license": "BSD3",
     "source-directories": [
@@ -8,6 +8,7 @@
         "../src"
     ],
     "exposed-modules": [],
+    "native-modules": true,
     "dependencies": {
         "NoRedInk/elm-decode-pipeline": "2.0.0 <= v < 3.0.0",
         "elm-lang/core": "4.0.5 <= v < 5.0.0",

--- a/example/elm-package.json
+++ b/example/elm-package.json
@@ -1,0 +1,18 @@
+{
+    "version": "1.0.0",
+    "summary": "helpful summary of your project, less than 80 characters",
+    "repository": "https://github.com/user/project.git",
+    "license": "BSD3",
+    "source-directories": [
+        "src/",
+        "../src/"
+    ],
+    "exposed-modules": [],
+    "native-modules": true,
+    "dependencies": {
+        "NoRedInk/elm-decode-pipeline": "2.0.0 <= v < 3.0.0",
+        "elm-lang/core": "4.0.5 <= v < 5.0.0",
+        "elm-lang/html": "1.1.0 <= v < 2.0.0"
+    },
+    "elm-version": "0.17.1 <= v < 0.18.0"
+}

--- a/example/elm-package.json
+++ b/example/elm-package.json
@@ -2,7 +2,7 @@
     "version": "1.0.0",
     "summary": "Example for the OpenSensorsIO/eventsource package",
     "repository": "https://github.com/OpenSensorsIO/eventsource.git",
-    "license": "BSD3",
+    "license": "MIT",
     "source-directories": [
         "src",
         "../src"

--- a/example/elm-package.json
+++ b/example/elm-package.json
@@ -1,7 +1,7 @@
 {
     "version": "1.0.0",
     "summary": "helpful summary of your project, less than 80 characters",
-    "repository": "https://github.com/user/project.git",
+    "repository": "https://github.com/OpenSensorsIO/eventsource.git",
     "license": "BSD3",
     "source-directories": [
         "src/",

--- a/example/elm-package.json
+++ b/example/elm-package.json
@@ -14,5 +14,5 @@
         "elm-lang/core": "4.0.5 <= v < 5.0.0",
         "elm-lang/html": "1.1.0 <= v < 2.0.0"
     },
-    "elm-version": "0.17.1 <= v < 0.18.0"
+    "elm-version": "0.17.0 <= v < 0.18.0"
 }

--- a/example/src/Simple.elm
+++ b/example/src/Simple.elm
@@ -1,0 +1,149 @@
+module Main exposing (..)
+
+import Html.App as Html
+import Html exposing (..)
+import Html.Attributes exposing (..)
+import Html.Events exposing (..)
+import Dict exposing (..)
+import Date exposing (..)
+import EventSource exposing (..)
+import Json.Decode
+import Json.Decode.Pipeline as JD
+
+
+-- Model
+
+
+type alias Url =
+    String
+
+
+type alias DatasetId =
+    Int
+
+
+type alias Event =
+    { dataset : DatasetId
+    , date : Date.Date
+    }
+
+
+type alias Channel =
+    { events : List (Result String Event)
+    , listening : Bool
+    }
+
+
+type ChannelMsg
+    = Receive (Result String Event)
+    | ToggleListening
+    | Clear
+
+
+type alias Model =
+    { eventRoot : Url
+    , channels : Dict DatasetId Channel
+    }
+
+
+emptyModel : Model
+emptyModel =
+    { eventRoot = "http://localhost:3000"
+    , channels = Dict.empty
+    }
+
+
+
+-- Update
+
+
+init : ( Model, Cmd Msg )
+init =
+    emptyModel ! []
+
+
+type Msg
+    = ChannelMsg DatasetId ChannelMsg
+
+
+update : Msg -> Model -> ( Model, Cmd Msg )
+update msg model =
+    case msg of
+        ChannelMsg datasetId submsg ->
+            let
+                updater =
+                    Maybe.map (updateChannel submsg)
+            in
+                ( { model
+                    | channels =
+                        Dict.update datasetId
+                            updater
+                            model.channels
+                  }
+                , Cmd.none
+                )
+
+
+updateChannel : ChannelMsg -> Channel -> Channel
+updateChannel msg channel =
+    case msg of
+        Receive event ->
+            { channel | events = List.take 25 <| event :: channel.events }
+
+        ToggleListening ->
+            { channel | listening = not channel.listening }
+
+        Clear ->
+            { channel | events = [] }
+
+
+
+-- Decoder
+
+
+decodeEvent : Json.Decode.Decoder Event
+decodeEvent =
+    JD.decode Event
+        |> JD.required "dataset" Json.Decode.int
+        |> JD.required "date" (Json.Decode.map (toFloat >> Date.fromTime) Json.Decode.int)
+
+
+listen : Url -> DatasetId -> Sub Msg
+listen eventRoot datasetId =
+    EventSource.listen (eventRoot ++ "/public/events/datasets/" ++ (toString datasetId))
+        (Json.Decode.decodeString decodeEvent >> Receive >> ChannelMsg datasetId)
+
+
+
+-- SUBSCRIPTIONS
+
+
+subscriptions : Model -> Sub Msg
+subscriptions model =
+    model.channels
+        |> Dict.filter (\_ channel -> channel.listening)
+        |> Dict.map (\key val -> (listen model.eventRoot key))
+        |> Dict.values
+        |> Sub.batch
+
+
+
+-- View
+
+
+view : Model -> Html Msg
+view model =
+    div [] [ text "Server sent events:" ]
+
+
+
+-- Main program
+
+
+app =
+    Html.program
+        { init = init
+        , update = update
+        , view = view
+        , subscriptions = subscriptions
+        }

--- a/example/src/Simple.elm
+++ b/example/src/Simple.elm
@@ -2,13 +2,11 @@ module Simple exposing (..)
 
 import Html.App as Html
 import Html exposing (..)
-import Html.Attributes exposing (..)
-import Html.Events exposing (..)
 import Dict exposing (..)
 import Date exposing (..)
 import EventSource exposing (..)
-import Json.Decode
-import Json.Decode.Pipeline as JD
+import Json.Decode exposing (..)
+import Json.Decode.Pipeline as JD exposing (..)
 
 
 -- Model

--- a/example/src/Simple.elm
+++ b/example/src/Simple.elm
@@ -1,4 +1,4 @@
-module Main exposing (..)
+module Simple exposing (..)
 
 import Html.App as Html
 import Html exposing (..)

--- a/src/EventSource/LowLevel.elm
+++ b/src/EventSource/LowLevel.elm
@@ -13,14 +13,14 @@ module EventSource.LowLevel
         , BadSend(..)
         )
 
-{-| Low-level bindings to [the JavaScript API for web sockets][ws]. This is
-useful primarily for making effect modules like [EventSource](EventSource). So
-if you happen to be the creator of Elixir’s Phoenix framework, and you want
+{-| Low-level bindings to [the JavaScript API for Server Sent Events][sse]. This
+is useful primarily for making effect modules like [EventSource](EventSource).
+So if you happen to be the creator of Elixir’s Phoenix framework, and you want
 it to be super easy to use channels, this module will help you make a really
 nice subscription-based API. If you are someone else, you probably do not want
 these things.
 
-[ws]: https://developer.mozilla.org/en-US/docs/Web/API/EventSource
+[sse]: https://developer.mozilla.org/en-US/docs/Web/API/EventSource
 
 # EventSources
 @docs EventSource

--- a/src/Native/EventSource.js
+++ b/src/Native/EventSource.js
@@ -5,7 +5,7 @@
    _elm_lang$core$Maybe$Just,
    A2, F2, F3
 */
-var _opensensorsio$website_datasubscriber$Native_EventSource = (function() {
+var _OpenSensorsIO$eventsource$Native_EventSource = (function() {
     var MIN_TIME_BETWEEN_MESSAGES_MS = 250;
 
     var open = function (options, url, settings) {


### PR DESCRIPTION
To get #2 in place, I have started adding an example module.

It doesn't work yet. In fact I still get an error that implies I'm probably declaring incorrectly the module in the elm-package. But it's probably a good start :)

Would love pointers in case I'm missing obvious stuff.

![__src_simple_elm_and___examples_07-websockets_elm](https://cloud.githubusercontent.com/assets/125707/19666705/ed9d49ea-9a54-11e6-9016-b5597e6596b3.jpg)

I have deliberately done it in a single file for now, just to make it a little easier the grok it.

I think the next thing to do after getting this to compile, is have some server side code to emit two different server-sent events and see how the app handles them.
